### PR TITLE
fix: removed provider check from newGeneration

### DIFF
--- a/logging/generation.go
+++ b/logging/generation.go
@@ -166,11 +166,6 @@ type Generation struct {
 }
 
 func newGeneration(c *GenerationConfig, w *writer) *Generation {
-	// Validating provider
-	if c.Provider != ProviderOpenAI && c.Provider != ProviderAzure && c.Provider != ProviderBedrock && c.Provider != ProviderAnthropic {
-		fmt.Printf("[MaximSDK] Invalid provider %s, allowed providers are %s, %s, %s, %s\n", c.Provider, ProviderOpenAI, ProviderAzure, ProviderBedrock, ProviderAnthropic)
-		return nil
-	}
 	return &Generation{
 		base: newBase(EntityGeneration, c.Id, &baseConfig{
 			SpanId: c.SpanId,


### PR DESCRIPTION
### TL;DR

Removed provider validation in the `newGeneration` function.

### What changed?

Removed the code block that validates the provider type in the `newGeneration` function in `logging/generation.go`. The validation was checking if the provider was one of the allowed types (OpenAI, Azure, Bedrock, or Anthropic).

### How to test?

1. Create a Generation with a non-standard provider type
2. Verify that the Generation is created successfully without validation errors
3. Ensure the rest of the Generation functionality works as expected

### Why make this change?

This change allows for more flexibility in provider types, removing the hard-coded validation that was limiting the system to only four specific providers. This enables support for additional providers without requiring code changes to the validation logic.