### PR TITLE
chore: removed unused import fmt

### DIFF
--- a/logging/generation.go
+++ b/logging/generation.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"time"
 )


### PR DESCRIPTION
### TL;DR

Removed unused import of "fmt" from the logging/generation.go file.

### What changed?

Removed the import of the "fmt" package from logging/generation.go as it was not being used in the code. This is a simple cleanup to remove an unnecessary dependency.

### How to test?

1. Verify that the code builds successfully without the "fmt" import
2. Run any existing tests to ensure functionality is not affected
3. Check that logging functionality continues to work as expected

### Why make this change?

Removing unused imports helps keep the codebase clean and reduces potential confusion. It also slightly improves compile times by eliminating unnecessary package imports.