### PR TITLE
[Maxim Go] Adds image generation logging support

### DIFF
--- a/logging/generation.go
+++ b/logging/generation.go
@@ -156,6 +156,11 @@ func (g *Generation) SetResult(r interface{}) {
 			"completion_tokens": 10,
 			"total_tokens": 20,
 		},
+		"cost": map[string]interface{}{ // optional if you want to override the cost
+			"input": 0.0,
+			"output": 0.0,
+			"total": 0.0,
+		},
 	})`)
 		return
 	}

--- a/logging/image_generation.go
+++ b/logging/image_generation.go
@@ -1,0 +1,229 @@
+package logging
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	uuidpkg "github.com/google/uuid"
+	"github.com/maximhq/maxim-go/schemas"
+)
+
+// isImageGenerationResult detects an OpenAI-style image generation response:
+// top-level "data" array with url or b64_json entries, and no "choices" (chat completions).
+func isImageGenerationResult(result interface{}) (*schemas.MaximImageGenerationResult, bool) {
+	b, err := json.Marshal(result)
+	if err != nil {
+		return nil, false
+	}
+	var top map[string]interface{}
+	if err := json.Unmarshal(b, &top); err != nil {
+		return nil, false
+	}
+	if _, hasChoices := top["choices"]; hasChoices {
+		return nil, false
+	}
+	rawData, ok := top["data"].([]interface{})
+	if !ok || len(rawData) == 0 {
+		return nil, false
+	}
+	if !isImageGenerationDataArray(rawData) {
+		return nil, false
+	}
+	var resp schemas.MaximImageGenerationResult
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, false
+	}
+	if len(resp.Data) == 0 {
+		return nil, false
+	}
+	return &resp, true
+}
+
+func isImageGenerationDataArray(data []interface{}) bool {
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if emb, ok := m["embedding"]; ok && emb != nil {
+			return false
+		}
+		if u, ok := m["url"].(string); ok && strings.TrimSpace(u) != "" {
+			return true
+		}
+		if b, ok := m["b64_json"].(string); ok && strings.TrimSpace(b) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func mimeFromOutputFormat(format string) string {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "png":
+		return "image/png"
+	case "jpeg", "jpg":
+		return "image/jpeg"
+	case "webp":
+		return "image/webp"
+	case "gif":
+		return "image/gif"
+	default:
+		return ""
+	}
+}
+
+func extFromMime(mime string) string {
+	switch mime {
+	case "image/png":
+		return "png"
+	case "image/jpeg":
+		return "jpg"
+	case "image/webp":
+		return "webp"
+	case "image/gif":
+		return "gif"
+	default:
+		return "png"
+	}
+}
+
+func urlAttachmentForGeneratedImage(imageURL, outputFormat string, index int) *UrlAttachment {
+	mime := mimeFromOutputFormat(outputFormat)
+	if mime == "" {
+		if u, err := url.Parse(imageURL); err == nil {
+			if q := u.Query().Get("rsct"); q != "" {
+				mime = mimeFromOutputFormat(q)
+			}
+		}
+	}
+	if mime == "" {
+		mime = mimeFromPath(imageURL)
+	}
+	if mime == "" || !strings.HasPrefix(mime, "image/") {
+		mime = "image/png"
+	}
+	ext := extFromMime(mime)
+	name := "image." + ext
+	if index > 0 {
+		name = fmt.Sprintf("image_%d.%s", index, ext)
+	}
+	return &UrlAttachment{
+		BaseAttachmentProps: BaseAttachmentProps{
+			ID:       uuidpkg.New().String(),
+			Name:     name,
+			MimeType: mime,
+		},
+		Type: AttachmentTypeURL,
+		URL:  imageURL,
+	}
+}
+
+func fileDataAttachmentFromB64JSON(b64, outputFormat string, index int) *FileDataAttachment {
+	if b64 == "" {
+		return nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil
+	}
+	mime := mimeFromOutputFormat(outputFormat)
+	if mime == "" {
+		mime = http.DetectContentType(raw)
+	}
+	if mime == "" || !strings.HasPrefix(mime, "image/") {
+		mime = "image/png"
+	}
+	ext := extFromMime(mime)
+	name := "image." + ext
+	if index > 0 {
+		name = fmt.Sprintf("image_%d.%s", index, ext)
+	}
+	return &FileDataAttachment{
+		BaseAttachmentProps: BaseAttachmentProps{
+			ID:       uuidpkg.New().String(),
+			Name:     name,
+			MimeType: mime,
+		},
+		Type: AttachmentTypeFileData,
+		Data: raw,
+	}
+}
+
+func imageGenerationResultToMaximLLMResult(resp *schemas.MaximImageGenerationResult) *schemas.MaximLLMResult {
+	content := assistantContentFromImagesResponse(resp)
+	u := normalisedGenerationUsage(resp.Usage)
+	return &schemas.MaximLLMResult{
+		ID:      resp.ID,
+		Model:   resp.Model,
+		Created: resp.Created,
+		Choices: []schemas.MaximLLMChoice{
+			{
+				Message: schemas.MaximLLMChoiceMessage{
+					Role:    "assistant",
+					Content: content,
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: u,
+	}
+}
+
+func assistantContentFromImagesResponse(resp *schemas.MaximImageGenerationResult) string {
+	for _, d := range resp.Data {
+		if strings.TrimSpace(d.RevisedPrompt) != "" {
+			return d.RevisedPrompt
+		}
+	}
+	var b strings.Builder
+	for _, d := range resp.Data {
+		if u := strings.TrimSpace(d.URL); u != "" {
+			b.WriteString("\n\n")
+			b.WriteString(fmt.Sprintf("![image](%s)", u))
+		}
+	}
+	return b.String()
+}
+
+func normalisedGenerationUsage(u *schemas.MaximImageGenerationUsage) schemas.Usage {
+	if u == nil {
+		return schemas.Usage{}
+	}
+	total := u.TotalTokens
+	if total == 0 && (u.InputTokens != 0 || u.OutputTokens != 0) {
+		total = u.InputTokens + u.OutputTokens
+	}
+	return schemas.Usage{
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      total,
+	}
+}
+
+// commitImageGenerationAttachments enqueues upload-attachment commits for each generated image.
+func commitImageGenerationAttachments(l *Logger, generationID string, resp *schemas.MaximImageGenerationResult) {
+	outFmt := resp.OutputFormat
+	for i, d := range resp.Data {
+		idx := d.Index
+		if idx == 0 && i > 0 {
+			idx = i
+		}
+		switch {
+		case strings.TrimSpace(d.URL) != "":
+			att := urlAttachmentForGeneratedImage(d.URL, outFmt, idx)
+			if att != nil {
+				l.writer.commit(newCommitLog(EntityGeneration, generationID, "upload-attachment", att))
+			}
+		case strings.TrimSpace(d.B64JSON) != "":
+			att := fileDataAttachmentFromB64JSON(d.B64JSON, outFmt, idx)
+			if att != nil {
+				l.writer.commit(newCommitLog(EntityGeneration, generationID, "upload-attachment", att))
+			}
+		}
+	}
+}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -267,10 +267,15 @@ func (l *Logger) AddEventToGeneration(gId, eventId, event string, tags *map[stri
 	addEvent(l.writer, EntityGeneration, gId, eventId, event, tags)
 }
 
-// AddResultToGeneration adds a result to the specified generation and marks it as ended
+// AddResultToGeneration adds a result to the specified generation and marks it as ended.
 func (l *Logger) AddResultToGeneration(gId string, result interface{}) {
+	var payload interface{} = result
+	if img, ok := isImageGenerationResult(result); ok {
+		commitImageGenerationAttachments(l, gId, img)
+		payload = imageGenerationResultToMaximLLMResult(img)
+	}
 	l.writer.commit(newCommitLog(EntityGeneration, gId, "result", map[string]interface{}{
-		"result": result,
+		"result": payload,
 	}))
 	end(l.writer, EntityGeneration, gId)
 }

--- a/schemas/generation.go
+++ b/schemas/generation.go
@@ -10,7 +10,7 @@ type MaximLLMChoiceMessage struct {
 // MaximLLMChoice represents a single choice in MaximLLMResult.
 type MaximLLMChoice struct {
 	Message      MaximLLMChoiceMessage `json:"message"`
-	FinishReason string               `json:"finish_reason"`
+	FinishReason string                `json:"finish_reason"`
 }
 
 // MaximLLMResult is the normalized LLM response format used across providers.
@@ -20,6 +20,7 @@ type MaximLLMResult struct {
 	Created int64            `json:"created"`
 	Choices []MaximLLMChoice `json:"choices"`
 	Usage   Usage            `json:"usage"`
+	Cost    *Cost            `json:"cost,omitempty"`
 }
 
 type GenerationError struct {
@@ -35,6 +36,7 @@ type ChatCompletionResult struct {
 	Model   string                 `json:"model"`
 	Choices []ChatCompletionChoice `json:"choices"`
 	Usage   Usage                  `json:"usage"`
+	Cost    *Cost                  `json:"cost,omitempty"`
 	Error   *GenerationError       `json:"error,omitempty"`
 }
 
@@ -45,6 +47,7 @@ type TextCompletionResult struct {
 	Model   string                 `json:"model"`
 	Choices []TextCompletionChoice `json:"choices"`
 	Usage   Usage                  `json:"usage"`
+	Cost    *Cost                  `json:"cost,omitempty"`
 	Error   *GenerationError       `json:"error,omitempty"`
 }
 
@@ -86,6 +89,12 @@ type Usage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
+type Cost struct {
+	Input  float64 `json:"input"`
+	Output float64 `json:"output"`
+	Total  float64 `json:"total"`
+}
+
 type CompletionRequestTextContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
@@ -104,4 +113,29 @@ type CompletionRequestContent interface{}
 type CompletionRequest struct {
 	Role    string      `json:"role"`
 	Content interface{} `json:"content"`
+}
+
+type MaximImageGenerationResult struct {
+	ID           string                     `json:"id,omitempty"`
+	Created      int64                      `json:"created,omitempty"`
+	Model        string                     `json:"model,omitempty"`
+	Data         []MaximImageGenerationData `json:"data"`
+	OutputFormat string                     `json:"output_format,omitempty"`
+	Background   string                     `json:"background,omitempty"`
+	Quality      string                     `json:"quality,omitempty"`
+	Size         string                     `json:"size,omitempty"`
+	Usage        *MaximImageGenerationUsage `json:"usage,omitempty"`
+}
+
+type MaximImageGenerationData struct {
+	URL           string `json:"url,omitempty"`
+	B64JSON       string `json:"b64_json,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+	Index         int    `json:"index"`
+}
+
+type MaximImageGenerationUsage struct {
+	InputTokens  int `json:"prompt_tokens,omitempty"`
+	OutputTokens int `json:"completion_tokens,omitempty"`
+	TotalTokens  int `json:"total_tokens,omitempty"`
 }

--- a/tests/openai_image_generation_e2e_test.go
+++ b/tests/openai_image_generation_e2e_test.go
@@ -1,0 +1,319 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/maxim-go/logging"
+	"github.com/maximhq/maxim-go/schemas"
+)
+
+// openAIImageGeneration calls the real OpenAI images/generations endpoint and returns the raw response map.
+func openAIImageGeneration(t *testing.T, apiKey string, prompt, model, responseFormat, size string) map[string]interface{} {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reqBody := map[string]interface{}{
+		"model":           model,
+		"prompt":          prompt,
+		"n":               1,
+		"response_format": responseFormat,
+		"size":            size,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("failed to marshal image generation request: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.openai.com/v1/images/generations", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("OpenAI image generation request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode image generation response: %v", err)
+	}
+	if errObj, ok := result["error"]; ok {
+		t.Fatalf("OpenAI image generation returned error: %v", errObj)
+	}
+	return result
+}
+
+// TestOpenAI_E2E_ImageGeneration_DallE2_B64JSON uses dall-e-2 with b64_json response format.
+// b64_json causes the SDK to upload actual image bytes to Maxim (via FileDataAttachment),
+// so the attachment contains persistent image data rather than an expiring URL reference.
+func TestOpenAI_E2E_ImageGeneration_DallE2_B64JSON(t *testing.T) {
+	requireMaximCredentials(t)
+	openAIKey := getOpenAIKey(t)
+
+	logger := logging.NewLogger(baseUrl, apiKey, &logging.LoggerConfig{
+		Id:        logRepoId,
+		AutoFlush: ptr(false),
+	})
+	defer logger.Flush()
+
+	const prompt = "a simple red circle on a white background"
+	traceID := uuid.NewString()
+	genID := uuid.NewString()
+
+	trace := logger.Trace(&logging.TraceConfig{Id: traceID})
+	logger.SetTraceInput(traceID, prompt)
+	logger.AddGenerationToTrace(traceID, &logging.GenerationConfig{
+		Id:       genID,
+		Provider: logging.ProviderOpenAI,
+		Model:    "dall-e-2",
+		Messages: []schemas.CompletionRequest{
+			{Role: "user", Content: prompt},
+		},
+		ModelParameters: map[string]interface{}{
+			"n":               1,
+			"size":            "256x256",
+			"response_format": "b64_json",
+		},
+	})
+
+	result := openAIImageGeneration(t, openAIKey, prompt, "dall-e-2", "b64_json", "256x256")
+
+	data, ok := result["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		t.Fatalf("expected non-empty data array, got: %v", result)
+	}
+	item, ok := data[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data[0] to be a map, got: %T", data[0])
+	}
+	b64, ok := item["b64_json"].(string)
+	if !ok || b64 == "" {
+		t.Fatalf("expected non-empty b64_json in data[0], got: %v", item)
+	}
+	t.Logf("dall-e-2 returned b64_json image (%d chars)", len(b64))
+
+	logger.AddResultToGeneration(genID, result)
+	logger.SetTraceOutput(traceID, prompt+" — image generated")
+	trace.End()
+	logger.Flush()
+
+	t.Log("Successfully logged dall-e-2 b64_json image generation to Maxim")
+}
+
+// TestOpenAI_E2E_ImageGeneration_DallE3_B64JSON uses dall-e-3 with b64_json.
+// dall-e-3 returns a revised_prompt in the response; the SDK uses it as the assistant message content.
+func TestOpenAI_E2E_ImageGeneration_DallE3_B64JSON(t *testing.T) {
+	requireMaximCredentials(t)
+	openAIKey := getOpenAIKey(t)
+
+	logger := logging.NewLogger(baseUrl, apiKey, &logging.LoggerConfig{
+		Id:        logRepoId,
+		AutoFlush: ptr(false),
+	})
+	defer logger.Flush()
+
+	const prompt = "a serene mountain landscape at sunset"
+	traceID := uuid.NewString()
+	genID := uuid.NewString()
+
+	trace := logger.Trace(&logging.TraceConfig{Id: traceID})
+	logger.SetTraceInput(traceID, prompt)
+	logger.AddGenerationToTrace(traceID, &logging.GenerationConfig{
+		Id:       genID,
+		Provider: logging.ProviderOpenAI,
+		Model:    "dall-e-3",
+		Messages: []schemas.CompletionRequest{
+			{Role: "user", Content: prompt},
+		},
+		ModelParameters: map[string]interface{}{
+			"n":               1,
+			"size":            "1024x1024",
+			"response_format": "b64_json",
+			"quality":         "standard",
+		},
+	})
+
+	result := openAIImageGeneration(t, openAIKey, prompt, "dall-e-3", "b64_json", "1024x1024")
+
+	data, ok := result["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		t.Fatalf("expected non-empty data array, got: %v", result)
+	}
+	item, ok := data[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data[0] to be a map, got: %T", data[0])
+	}
+	b64, ok := item["b64_json"].(string)
+	if !ok || b64 == "" {
+		t.Fatalf("expected non-empty b64_json in data[0], got: %v", item)
+	}
+	revisedPrompt, ok := item["revised_prompt"].(string)
+	if !ok || revisedPrompt == "" {
+		t.Fatalf("expected non-empty revised_prompt in data[0], got: %v", item)
+	}
+	t.Logf("dall-e-3 b64_json: %d chars, revised_prompt: %q", len(b64), revisedPrompt)
+
+	logger.AddResultToGeneration(genID, result)
+	logger.SetTraceOutput(traceID, prompt+" — image generated")
+	trace.End()
+	logger.Flush()
+
+	t.Log("Successfully logged dall-e-3 b64_json image generation to Maxim")
+}
+
+// TestOpenAI_E2E_ImageGeneration_DallE3_URL uses dall-e-3 with url response format.
+// NOTE: DALL-E pre-signed URLs expire in ~1 hour. Maxim stores the URL reference but
+// the image will not be viewable after expiry. Use b64_json for persistent image data.
+func TestOpenAI_E2E_ImageGeneration_DallE3_URL(t *testing.T) {
+	requireMaximCredentials(t)
+	openAIKey := getOpenAIKey(t)
+
+	logger := logging.NewLogger(baseUrl, apiKey, &logging.LoggerConfig{
+		Id:        logRepoId,
+		AutoFlush: ptr(false),
+	})
+	defer logger.Flush()
+
+	const prompt = "a futuristic city skyline at night"
+	traceID := uuid.NewString()
+	genID := uuid.NewString()
+
+	trace := logger.Trace(&logging.TraceConfig{Id: traceID})
+	logger.SetTraceInput(traceID, prompt)
+	logger.AddGenerationToTrace(traceID, &logging.GenerationConfig{
+		Id:       genID,
+		Provider: logging.ProviderOpenAI,
+		Model:    "dall-e-3",
+		Messages: []schemas.CompletionRequest{
+			{Role: "user", Content: prompt},
+		},
+		ModelParameters: map[string]interface{}{
+			"n":               1,
+			"size":            "1024x1024",
+			"response_format": "url",
+			"quality":         "standard",
+		},
+	})
+
+	result := openAIImageGeneration(t, openAIKey, prompt, "dall-e-3", "url", "1024x1024")
+
+	data, ok := result["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		t.Fatalf("expected non-empty data array, got: %v", result)
+	}
+	item, ok := data[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data[0] to be a map, got: %T", data[0])
+	}
+	imageURL, ok := item["url"].(string)
+	if !ok || imageURL == "" {
+		t.Fatalf("expected non-empty url in data[0], got: %v", item)
+	}
+	revisedPrompt, ok := item["revised_prompt"].(string)
+	if !ok || revisedPrompt == "" {
+		t.Fatalf("expected non-empty revised_prompt in data[0], got: %v", item)
+	}
+	t.Logf("dall-e-3 url: %s, revised_prompt: %q", imageURL, revisedPrompt)
+
+	logger.AddResultToGeneration(genID, result)
+	logger.SetTraceOutput(traceID, prompt+" — image generated")
+	trace.End()
+	logger.Flush()
+
+	t.Log("Successfully logged dall-e-3 URL image generation to Maxim")
+}
+
+// TestOpenAI_E2E_ImageGeneration_DallE2_MultipleImages generates 2 images with dall-e-2
+// and verifies that each produces its own attachment entry in Maxim.
+func TestOpenAI_E2E_ImageGeneration_DallE2_MultipleImages(t *testing.T) {
+	requireMaximCredentials(t)
+	openAIKey := getOpenAIKey(t)
+
+	logger := logging.NewLogger(baseUrl, apiKey, &logging.LoggerConfig{
+		Id:        logRepoId,
+		AutoFlush: ptr(false),
+	})
+	defer logger.Flush()
+
+	const prompt = "a simple geometric pattern"
+	traceID := uuid.NewString()
+	genID := uuid.NewString()
+
+	trace := logger.Trace(&logging.TraceConfig{Id: traceID})
+	logger.SetTraceInput(traceID, prompt)
+	logger.AddGenerationToTrace(traceID, &logging.GenerationConfig{
+		Id:       genID,
+		Provider: logging.ProviderOpenAI,
+		Model:    "dall-e-2",
+		Messages: []schemas.CompletionRequest{
+			{Role: "user", Content: prompt},
+		},
+		ModelParameters: map[string]interface{}{
+			"n":               2,
+			"size":            "256x256",
+			"response_format": "b64_json",
+		},
+	})
+
+	// Request 2 images from dall-e-2
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reqBody := map[string]interface{}{
+		"model":           "dall-e-2",
+		"prompt":          prompt,
+		"n":               2,
+		"response_format": "b64_json",
+		"size":            "256x256",
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.openai.com/v1/images/generations", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+openAIKey)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("OpenAI request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if errObj, ok := result["error"]; ok {
+		t.Fatalf("OpenAI returned error: %v", errObj)
+	}
+
+	data, ok := result["data"].([]interface{})
+	if !ok || len(data) < 2 {
+		t.Fatalf("expected at least 2 images in data array, got: %v", result)
+	}
+	t.Logf("dall-e-2 returned %d images", len(data))
+
+	logger.AddResultToGeneration(genID, result)
+	logger.SetTraceOutput(traceID, prompt+" — 2 images generated")
+	trace.End()
+	logger.Flush()
+
+	t.Logf("Successfully logged dall-e-2 multi-image generation (%d images) to Maxim", len(data))
+}


### PR DESCRIPTION
### TL;DR

Added support for OpenAI image generation logging with automatic attachment handling for generated images.

### What changed?

- Added detection and processing of OpenAI-style image generation responses in the logging system
- Implemented automatic conversion of image generation results to normalized LLM format for consistent logging
- Added support for both URL-based and base64-encoded image attachments with proper MIME type detection
- Extended schemas to include cost tracking fields and image generation data structures
- Created comprehensive end-to-end tests for DALL-E 2 and DALL-E 3 image generation with different response formats

### How to test?

Run the new end-to-end tests:
- `TestOpenAI_E2E_ImageGeneration_DallE2_B64JSON` - Tests DALL-E 2 with base64 image data
- `TestOpenAI_E2E_ImageGeneration_DallE3_B64JSON` - Tests DALL-E 3 with base64 image data  
- `TestOpenAI_E2E_ImageGeneration_DallE3_URL` - Tests DALL-E 3 with URL-based images
- `TestOpenAI_E2E_ImageGeneration_DallE2_MultipleImages` - Tests multiple image generation

These tests require valid OpenAI and Maxim API credentials.

### Why make this change?

This enables proper logging and tracking of image generation workflows in Maxim, providing visibility into AI image creation processes. The automatic attachment handling ensures generated images are properly stored and associated with their generation logs, supporting both temporary URL references and persistent base64-encoded image data.